### PR TITLE
Fix: Permalink to comment does not scroll properly to comment in image posts

### DIFF
--- a/ui/src/pages/Post/Comment.jsx
+++ b/ui/src/pages/Post/Comment.jsx
@@ -35,6 +35,7 @@ const Comment = ({
   isBanned,
   canVote,
   canComment,
+  imageHeight,
 }) => {
   const dispatch = useDispatch();
 
@@ -208,9 +209,14 @@ const Comment = ({
   const focused = focusId === comment.id;
   useEffect(() => {
     if (focused && div.current) {
-      const pos =
-        document.documentElement.scrollTop + div.current.getBoundingClientRect().top - 100;
-      window.scrollTo(0, pos);
+      if (imageHeight) {
+        const pos = imageHeight + div.current.getBoundingClientRect().top - 500;
+        window.scrollTo(0, pos);
+      } else {
+        const pos =
+          document.documentElement.scrollTop + div.current.getBoundingClientRect().top - 100;
+        window.scrollTo(0, pos);
+      }
     }
   }, [focused, focusId]);
 
@@ -721,6 +727,7 @@ Comment.propTypes = {
   isBanned: PropTypes.bool.isRequired,
   canVote: PropTypes.bool.isRequired,
   canComment: PropTypes.bool.isRequired,
+  imageHeight: PropTypes.number,
 };
 
 export default Comment;

--- a/ui/src/pages/Post/CommentSection.jsx
+++ b/ui/src/pages/Post/CommentSection.jsx
@@ -17,6 +17,7 @@ const CommentSection = ({
   isBanned,
   canVote,
   canComment,
+  imageHeight,
 }) => {
   const dispatch = useDispatch();
 
@@ -119,6 +120,7 @@ const CommentSection = ({
           isBanned={isBanned}
           canVote={canVote}
           canComment={canComment}
+          imageHeight={imageHeight}
         />
       );
     }
@@ -162,6 +164,7 @@ CommentSection.propTypes = {
   isBanned: PropTypes.bool.isRequired,
   canVote: PropTypes.bool.isRequired,
   canComment: PropTypes.bool.isRequired,
+  imageHeight: PropTypes.number,
 };
 
 export default CommentSection;

--- a/ui/src/pages/Post/index.jsx
+++ b/ui/src/pages/Post/index.jsx
@@ -264,6 +264,7 @@ const Post = () => {
 
   const canVote = !post.locked;
   const canComment = !(post.locked || isBanned);
+  const imageHeight = showImage ? post.image.height : 0;
 
   const getDeletedBannerText = (post) => {
     if (post.deletedContent) {
@@ -564,6 +565,7 @@ const Post = () => {
                     isBanned={isBanned}
                     canVote={canVote}
                     canComment={canComment}
+                    imageHeight={imageHeight}
                   />
                   {post.noComments === 0 && (
                     <div className="post-comments-none is-no-m">No comments yet.</div>


### PR DESCRIPTION
The image height is passed down to the comment, allowing it to calculate the proper scroll position. Only fixes this when the comment is not hidden behind a show more/pagination